### PR TITLE
Fixing string escaping issue(#3127)

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "react-dnd": "^5.0.0",
     "react-dnd-html5-backend": "^5.0.1",
     "react-dom": "^16.4.2",
+    "react-html-parser": "^2.0.2",
     "react-redux": "^5.0.7",
     "react-scripts": "^2.0.0",
     "react-transition-group": "1.x",

--- a/src/components/HeadingForm.js
+++ b/src/components/HeadingForm.js
@@ -10,6 +10,7 @@ import {
 } from 'react-bootstrap';
 import * as actions from '../actions/show-forms';
 import PropTypes from 'prop-types';
+import ReactHtmlParser from 'react-html-parser';
 
 const structuralMetadataUtils = new StructuralMetadataUtils();
 class HeadingForm extends Component {
@@ -61,7 +62,7 @@ class HeadingForm extends Component {
     );
     let options = allHeaders.map(header => (
       <option value={header.label} key={header.label}>
-        {header.label}
+        {ReactHtmlParser(header.label)}
       </option>
     ));
 
@@ -131,7 +132,7 @@ class HeadingForm extends Component {
             <ControlLabel>Title</ControlLabel>
             <FormControl
               type="text"
-              value={this.state.headingTitle}
+              value={ReactHtmlParser(this.state.headingTitle)}
               onChange={this.handleHeadingChange}
             />
             <FormControl.Feedback />

--- a/src/components/ListItem.js
+++ b/src/components/ListItem.js
@@ -7,6 +7,7 @@ import * as showFormActions from '../actions/show-forms';
 import PropTypes from 'prop-types';
 import { ItemTypes } from '../services/Constants';
 import { DragSource, DropTarget } from 'react-dnd';
+import ReactHtmlParser from 'react-html-parser';
 
 const spanSource = {
   beginDrag(props) {
@@ -141,11 +142,11 @@ class ListItem extends Component {
           <div className="row-wrapper">
             {type === 'span' && (
               <span className="structure-title">
-                {label} ({begin} - {end})
+                {ReactHtmlParser(label)} ({begin} - {end})
               </span>
             )}
             {type === 'div' && (
-              <div className="structure-title heading">{label}</div>
+              <div className="structure-title heading">{ReactHtmlParser(label)}</div>
             )}
             <EditControls
               handleDelete={this.handleDelete}

--- a/src/components/TimespanForm.js
+++ b/src/components/TimespanForm.js
@@ -12,6 +12,7 @@ import * as showFormActions from '../actions/show-forms';
 import * as smActions from '../actions/sm-data';
 import { connect } from 'react-redux';
 import StructuralMetadataUtils from '../services/StructuralMetadataUtils';
+import ReactHtmlParser from 'react-html-parser';
 
 const structuralMetadataUtils = new StructuralMetadataUtils();
 
@@ -303,7 +304,7 @@ class TimespanForm extends Component {
             <ControlLabel>Title</ControlLabel>
             <FormControl
               type="text"
-              value={timespanTitle}
+              value={ReactHtmlParser(timespanTitle)}
               onChange={this.handleInputChange}
             />
             <FormControl.Feedback />
@@ -353,7 +354,7 @@ class TimespanForm extends Component {
               <option value="">Select...</option>
               {this.state.validHeadings.map(item => (
                 <option value={item.label} key={item.label}>
-                  {item.label}
+                  {ReactHtmlParser(item.label)}
                 </option>
               ))}
             </FormControl>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2736,6 +2736,11 @@ domelementtype@1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.0.tgz#b17aed82e8ab59e52dd9c19b1756e0fc187204c2"
 
+domelementtype@^1.3.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.1.tgz#d048c44b37b0d10a7f2a3d5fee3f4333d790481f"
+  integrity sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==
+
 domelementtype@~1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.1.3.tgz#bd28773e2642881aec51544924299c5cd822185b"
@@ -2752,6 +2757,13 @@ domhandler@2.1:
   dependencies:
     domelementtype "1"
 
+domhandler@^2.3.0:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-2.4.2.tgz#8805097e933d65e85546f726d60f5eb88b44f803"
+  integrity sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==
+  dependencies:
+    domelementtype "1"
+
 domutils@1.1:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.1.6.tgz#bddc3de099b9a2efacc51c623f28f416ecc57485"
@@ -2765,7 +2777,7 @@ domutils@1.5.1:
     dom-serializer "0"
     domelementtype "1"
 
-domutils@^1.7.0:
+domutils@^1.5.1, domutils@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.7.0.tgz#56ea341e834e06e6748af7a1cb25da67ea9f8c2a"
   dependencies:
@@ -2857,6 +2869,11 @@ enhanced-resolve@^4.1.0:
     graceful-fs "^4.1.2"
     memory-fs "^0.4.0"
     tapable "^1.0.0"
+
+entities@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.2.tgz#bdfa735299664dfafd34529ed4f8522a275fea56"
+  integrity sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==
 
 entities@~1.1.1:
   version "1.1.1"
@@ -4018,6 +4035,18 @@ html-webpack-plugin@4.0.0-alpha.2:
     pretty-error "^2.0.2"
     tapable "^1.0.0"
     util.promisify "1.0.0"
+
+htmlparser2@^3.9.0:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.10.0.tgz#5f5e422dcf6119c0d983ed36260ce9ded0bee464"
+  integrity sha512-J1nEUGv+MkXS0weHNWVKJJ+UrLfePxRWpN3C9bEi9fLxL2+ggW94DQvgYVXsaT30PGwYRIZKNZXuyMhp3Di4bQ==
+  dependencies:
+    domelementtype "^1.3.0"
+    domhandler "^2.3.0"
+    domutils "^1.5.1"
+    entities "^1.1.1"
+    inherits "^2.0.1"
+    readable-stream "^3.0.6"
 
 htmlparser2@~3.3.0:
   version "3.3.0"
@@ -7150,6 +7179,13 @@ react-error-overlay@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-5.1.0.tgz#c516995a5652e7bfbed8b497910d5280df74a7e8"
 
+react-html-parser@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/react-html-parser/-/react-html-parser-2.0.2.tgz#6dbe1ddd2cebc1b34ca15215158021db5fc5685e"
+  integrity sha512-XeerLwCVjTs3njZcgCOeDUqLgNIt/t+6Jgi5/qPsO/krUWl76kWKXMeVs2LhY2gwM6X378DkhLjur0zUQdpz0g==
+  dependencies:
+    htmlparser2 "^3.9.0"
+
 react-is@^16.3.2:
   version "16.5.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.5.0.tgz#2ec7c192709698591efe13722fab3ef56144ba55"
@@ -7318,6 +7354,15 @@ readable-stream@1.0:
     inherits "~2.0.1"
     isarray "0.0.1"
     string_decoder "~0.10.x"
+
+readable-stream@^3.0.6:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.1.1.tgz#ed6bbc6c5ba58b090039ff18ce670515795aeb06"
+  integrity sha512-DkN66hPyqDhnIQ6Jcsvx9bFjhw214O4poMBcIMgPVpQvNy9a0e0Uhg5SqySyDKAmUlwt8LonTBz1ezOnM8pUdA==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
 
 readdirp@^2.0.0:
   version "2.1.0"
@@ -8123,6 +8168,13 @@ string_decoder@^1.0.0, string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
+string_decoder@^1.1.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.2.0.tgz#fe86e738b19544afe70469243b2a1ee9240eae8d"
+  integrity sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==
+  dependencies:
+    safe-buffer "~5.1.0"
+
 string_decoder@~0.10.x:
   version "0.10.31"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
@@ -8610,7 +8662,7 @@ use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
 
-util-deprecate@~1.0.1:
+util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
 


### PR DESCRIPTION
Structural metadata editor displays HTML escaping codes instead of their character replacements. This is fixed using react-html-parser package.