### PR TITLE
Add MP3 to match waveform and structure data

### DIFF
--- a/src/components/Waveform.js
+++ b/src/components/Waveform.js
@@ -13,7 +13,7 @@ import APIUtils from '../api/Utils';
 import * as actions from '../actions/show-forms';
 import { connect } from 'react-redux';
 
-import soundMP3 from '../data/TOL_6min_720p_download.mp3';
+import soundMP3 from '../data/utah_phillips_one.mp3';
 
 const apiUtils = new APIUtils();
 


### PR DESCRIPTION
Use the actual audio of the item on Spruce. Makes it so Peak.js behaves normally and so the audio matches to the waveform data.

Closes #19 