### PR TITLE
Error boundary implementation for Peaks waveform component rendering

### DIFF
--- a/src/components/WaveformErrorBoundary.js
+++ b/src/components/WaveformErrorBoundary.js
@@ -1,0 +1,24 @@
+import React, { Component } from 'react';
+import { Alert } from 'react-bootstrap';
+
+class WaveformErrorBoundary extends Component {
+  state = { error: '' };
+
+  componentDidCatch(error, errorInfo) {
+    this.setState({ error, errorInfo });
+  }
+
+  render() {
+    if (this.state.error) {
+      return (
+        <Alert bsStyle="danger">
+          <p>Error rendering Peak.js waveform</p>
+        </Alert>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default WaveformErrorBoundary;


### PR DESCRIPTION
fixes #31 

This PR wraps any component rendering errors in a React error boundary.   Error boundaries aren't used typically for async network requests, or event handling.... so limited scope of this pattern to just component rendering errors.