### PR TITLE
Only handle segments when editing a span.

### DIFF
--- a/src/components/ListItem.js
+++ b/src/components/ListItem.js
@@ -72,7 +72,9 @@ class ListItem extends Component {
       clonedSegment: this.props.peaksInstance.segments.getSegment(id)
     });
 
-    this.props.activateSegment(this.props.item.id);
+    if (this.props.item.type === 'span') {
+      this.props.activateSegment(this.props.item.id);
+    }
 
     this.setState({ editing: true });
   };
@@ -80,10 +82,12 @@ class ListItem extends Component {
   handleEditFormCancel = (flag = 'cancel') => {
     this.setState({ editing: false });
 
-    this.props.deactivateSegment(this.props.item.id);
+    if (this.props.item.type === 'span') {
+      this.props.deactivateSegment(this.props.item.id);
 
-    if (flag === 'cancel') {
-      this.props.revertSegment(this.props.item.id, this.state.clonedSegment);
+      if (flag === 'cancel') {
+        this.props.revertSegment(this.props.item.id, this.state.clonedSegment);
+      }
     }
   };
 

--- a/src/components/ListItemEditForm.js
+++ b/src/components/ListItemEditForm.js
@@ -46,14 +46,16 @@ class ListItemEditForm extends Component {
     let item = structuralMetadataUtils.findItem(id, clonedItems);
     /* eslint-enable */
 
-    // Updated segment through waveform
-    let updatedSegment = this.props.peaksInstance.segments.getSegment(id);
+    if (this.props.item.type === 'span') {
+      // Updated segment through waveform
+      let updatedSegment = this.props.peaksInstance.segments.getSegment(id);
 
-    // Assign changes made through waveform to structure
-    payload.beginTime = structuralMetadataUtils.toHHmmss(
-      updatedSegment.startTime
-    );
-    payload.endTime = structuralMetadataUtils.toHHmmss(updatedSegment.endTime);
+      // Assign changes made through waveform to structure
+      payload.beginTime = structuralMetadataUtils.toHHmmss(
+        updatedSegment.startTime
+      );
+      payload.endTime = structuralMetadataUtils.toHHmmss(updatedSegment.endTime);
+    }
 
     // Update item values
     item = this.addUpdatedValues(item, payload);


### PR DESCRIPTION
Editing headings was broken because it was attempting to work with associated peaks segments.  This PR wraps segment handling code in a check to ensure the list item is a span.