### PR TITLE
Deleting segments when headers with child timespans are deleted

### DIFF
--- a/src/__mocks__/peaks.js
+++ b/src/__mocks__/peaks.js
@@ -26,7 +26,7 @@ export const Peaks = jest.fn(opts => {
   };
   peaks.segments = {
     getSegment: jest.fn(id => {
-      peaks.segments._segments.find(seg => {
+      return peaks.segments._segments.find(seg => {
         return seg.id === id;
       });
     }),
@@ -42,7 +42,9 @@ export const Peaks = jest.fn(opts => {
     }),
     removeById: jest.fn(id => {
       let index = peaks.segments._segments.map(seg => seg.id).indexOf(id);
-      peaks.segments._segments.splice(index, 1);
+      if (index >= 0) {
+        return peaks.segments._segments.splice(index, 1);
+      }
     }),
     _peaks: peaks,
     _segments: [

--- a/src/actions/peaks-instance.js
+++ b/src/actions/peaks-instance.js
@@ -15,10 +15,10 @@ export function insertNewSegment(span) {
   };
 }
 
-export function deleteSegment(id) {
+export function deleteSegment(item) {
   return {
     type: types.DELETE_SEGMENT,
-    payload: id
+    payload: item
   };
 }
 

--- a/src/components/ListItem.js
+++ b/src/components/ListItem.js
@@ -58,9 +58,9 @@ class ListItem extends Component {
   };
 
   handleDelete = () => {
-    const { id } = this.props.item;
-    this.props.deleteItem(id);
-    this.props.deleteSegment(id);
+    const { item } = this.props;
+    this.props.deleteItem(item.id);
+    this.props.deleteSegment(item);
   };
 
   handleEditClick = () => {

--- a/src/reducers/peaks-instance.js
+++ b/src/reducers/peaks-instance.js
@@ -15,7 +15,7 @@ const peaksInstance = (state = initialState, action) => {
       return waveformUtils.rebuildPeaks(newState);
 
     case types.DELETE_SEGMENT:
-      newState = waveformUtils.deleteSegment(action.payload, {
+      newState = waveformUtils.deleteSegments(action.payload, {
         ...state
       });
       return waveformUtils.rebuildPeaks(newState);

--- a/src/services/WaveformDataUtils.js
+++ b/src/services/WaveformDataUtils.js
@@ -68,11 +68,27 @@ export default class WaveformDataUtils {
 
   /**
    * Delete the corresponding segment when a timespan is deleted
-   * @param {String} id - ID of the segment that is being deleted
+   * @param {Object} item - item to be deleted
    * @param {Object} peaksInstance - peaks instance for the current waveform
    */
-  deleteSegment(id, peaksInstance) {
-    peaksInstance.segments.removeById(id);
+  deleteSegments(item, peaksInstance) {
+    let deleteChildren = item => {
+      let children = item.items;
+      for (let child of children) {
+        if (child.type === 'span') {
+          peaksInstance.segments.removeById(child.id);
+        }
+        if (child.items && child.items.length > 0) {
+          deleteChildren(child);
+        }
+      }
+    };
+
+    if (item.type === 'div') {
+      deleteChildren(item);
+    }
+
+    peaksInstance.segments.removeById(item.id);
     return peaksInstance;
   }
 
@@ -109,13 +125,13 @@ export default class WaveformDataUtils {
         this.deactivateSegment(seg.id, peaksInstance)
       );
     }
-    // Copy the current segment
-    let tempSegment = peaksInstance.segments.getSegment(id);
+
     // Remove the current segment
-    peaksInstance.segments.removeById(id);
+    const [removedSegment] = peaksInstance.segments.removeById(id);
+
     // Create a new segment with the same properties and set editable to true
     peaksInstance.segments.add({
-      ...tempSegment,
+      ...removedSegment,
       editable: true,
       color: COLOR_PALETTE[2]
     });
@@ -133,9 +149,6 @@ export default class WaveformDataUtils {
    * @param {Object} peaksInstance - current peaks instance for the waveform
    */
   deactivateSegment(id, peaksInstance) {
-    // Copy the current segment
-    let tempSegment = peaksInstance.segments.getSegment(id);
-
     // Sort segments by start time
     let segments = peaksInstance.segments
       .getSegments()
@@ -144,10 +157,10 @@ export default class WaveformDataUtils {
     let index = segments.map(seg => seg.id).indexOf(id);
 
     // Remove the current segment
-    peaksInstance.segments.removeById(id);
+    const [removedSegment] = peaksInstance.segments.removeById(id);
     // Create a new segment and revert to its original color
     peaksInstance.segments.add({
-      ...tempSegment,
+      ...removedSegment,
       editable: false,
       color: this.isOdd(index) ? COLOR_PALETTE[1] : COLOR_PALETTE[0]
     });


### PR DESCRIPTION
This fixes #34 
With these changes the Peaks waveform updates when headers with child timespans are deleted. Previously Peaks was updated only when a timespan was deleted.