### PR TITLE
Remove delete functionality from top root element in structure

### DIFF
--- a/src/components/ListItem.js
+++ b/src/components/ListItem.js
@@ -142,7 +142,7 @@ class ListItem extends Component {
                   {label} ({begin} - {end})
                 </span>
               )}
-              {type === 'div' && (
+              {(type === 'div' || type === 'root') && (
                 <div className="structure-title heading">{label}</div>
               )}
               <ListItemControls

--- a/src/components/ListItemControls.js
+++ b/src/components/ListItemControls.js
@@ -37,15 +37,17 @@ const ListItemControls = props => {
           <FontAwesomeIcon icon="pen" />
         </Button>
       </OverlayTrigger>
-      <OverlayTrigger placement="right" overlay={tooltip('Delete')}>
-        <Button
-          bsStyle="link"
-          onClick={handleDelete}
-          disabled={showForms.disabled}
-        >
-          <FontAwesomeIcon icon="trash" />
-        </Button>
-      </OverlayTrigger>
+      {itemType !== 'root' && (
+        <OverlayTrigger placement="right" overlay={tooltip('Delete')}>
+          <Button
+            bsStyle="link"
+            onClick={handleDelete}
+            disabled={showForms.disabled}
+          >
+            <FontAwesomeIcon icon="trash" />
+          </Button>
+        </OverlayTrigger>
+      )}
     </div>
   );
 };

--- a/src/components/ListItemEditForm.js
+++ b/src/components/ListItemEditForm.js
@@ -22,14 +22,13 @@ class ListItemEditForm extends Component {
   };
 
   addUpdatedValues(item, payload) {
-    if (item.type === 'div') {
+    if (item.type === 'div' || item.type === 'root') {
       item.label = payload.headingTitle;
     } else if (item.type === 'span') {
       item.label = payload.timespanTitle;
       item.begin = payload.beginTime;
       item.end = payload.endTime;
     }
-
     return item;
   }
 
@@ -69,7 +68,7 @@ class ListItemEditForm extends Component {
       );
     }
 
-    if (item.type === 'div') {
+    if (item.type === 'div' || item.type === 'root') {
       return (
         <HeadingInlineForm
           item={item}

--- a/src/containers/StructureOutputContainer.js
+++ b/src/containers/StructureOutputContainer.js
@@ -9,19 +9,24 @@ import uuidv1 from 'uuid/v1';
 import { cloneDeep } from 'lodash';
 import { buildSMUI } from '../actions/sm-data';
 
-const apiUtils = new APIUtils();
-
 class StructureOutputContainer extends Component {
+  constructor(props) {
+    super(props);
+    this.apiUtils = new APIUtils();
+  }
   state = {
     alertObj: {}
   };
 
   async componentDidMount() {
     try {
-      const response = await apiUtils.getRequest('structure.json');
+      const response = await this.apiUtils.getRequest('structure.json');
 
       // Add unique ids to every object
       let smData = this.addIds([response.data]);
+
+      // Tag the root element
+      this.markRootElement(smData);
 
       // Update the redux store
       this.props.buildSMUI(smData);
@@ -57,6 +62,12 @@ class StructureOutputContainer extends Component {
     return structureWithIds;
   }
 
+  markRootElement(smData) {
+    if (smData.length > 0) {
+      smData[0].type = 'root';
+    }
+  }
+
   handleFetchError(error) {
     let status = error.response !== undefined ? error.response.status : -2;
     const alertObj = configureAlert(status);
@@ -77,7 +88,7 @@ class StructureOutputContainer extends Component {
 
   handleSaveItClick = () => {
     let postData = { json: this.props.smData[0] };
-    apiUtils
+    this.apiUtils
       .postRequest('structure.json', postData)
       .then(response => {
         const { status } = response;

--- a/src/containers/StructureOutputContainer.test.js
+++ b/src/containers/StructureOutputContainer.test.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import StructureOutputContainer from './StructureOutputContainer';
+import { mount } from 'enzyme';
+import thunk from 'redux-thunk';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import mockAxios from 'axios';
+import { testMetadataStructure } from '../test/TestStructure';
+
+const mockStore = configureStore([thunk]);
+
+describe('StructureOutputContainer component', () => {
+  let store;
+  beforeEach(() => {
+    store = mockStore({
+      smData: [],
+      buildSMUI: jest.fn()
+    });
+  });
+  test('component mounts without crashing', () => {
+    mockAxios.get.mockImplementationOnce(() => {
+      return Promise.resolve({
+        data: testMetadataStructure[0]
+      });
+    });
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <StructureOutputContainer />
+      </Provider>
+    );
+    expect(mockAxios.get).toHaveBeenCalledTimes(1);
+    expect(wrapper.find('h3').instance()).toBeDefined();
+    expect(wrapper.find('Button').instance().props.children).toBe(
+      'Save Structure'
+    );
+  });
+});

--- a/src/reducers/show-forms.js
+++ b/src/reducers/show-forms.js
@@ -1,7 +1,6 @@
 import * as types from '../actions/types';
 
 const initialState = {
-  alert: false,
   disabled: false
 };
 
@@ -10,13 +9,11 @@ const showForms = (state = initialState, action) => {
     case types.IS_EDITING_TIMESPAN:
       if (action.code === 0) {
         return Object.assign({}, state, {
-          statusCode: action.code,
           disabled: true
         });
       }
 
       return Object.assign({}, state, {
-        statusCode: action.code,
         disabled: false
       });
 

--- a/src/services/form-helper.js
+++ b/src/services/form-helper.js
@@ -9,7 +9,7 @@ export function getExistingFormValues(id, smData, peaks = {}) {
   let item = structuralMetadataUtils.findItem(id, smData);
 
   // Heading
-  if (item.type === 'div') {
+  if (item.type === 'div' || item.type === 'root') {
     return {
       headingTitle: item.label
     };

--- a/yarn.lock
+++ b/yarn.lock
@@ -8953,24 +8953,6 @@ rxjs@^6.1.0, rxjs@^6.4.0:
   dependencies:
     tslib "^1.9.0"
 
-rxjs@^6.4.0:
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.4.0.tgz#f3bb0fe7bda7fb69deac0c16f17b50b0b8790504"
-  integrity sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==
-  dependencies:
-    tslib "^1.9.0"
-
-rxjs@^6.4.0:
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.4.0.tgz#f3bb0fe7bda7fb69deac0c16f17b50b0b8790504"
-  integrity sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==
-  dependencies:
-    tslib "^1.9.0"
-
-safe-buffer@5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
-
 safe-buffer@5.1.2, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"


### PR DESCRIPTION
This fixes #49 

Removed delete icon for the top element. In the current XML editor, the top element can't be deleted, which is created when a file is ingested. Therefore, this implementation is based on the assumption, the `structure.json` file retrieved from the server always has the top element.