### PR TITLE
Fix last segment's missing handle when editing

### DIFF
--- a/src/__mocks__/peaks.js
+++ b/src/__mocks__/peaks.js
@@ -23,8 +23,12 @@ export const Peaks = jest.fn(opts => {
     getCurrentTime: jest.fn(() => {
       return peaks.player._mediaElement.currentTime;
     }),
+    getDuration: jest.fn(() => {
+      return peaks.player._mediaElement.duration;
+    }),
     _mediaElement: {
-      currentTime: 0
+      currentTime: 0,
+      duration: 1738.945306
     }
   };
   peaks.segments = {

--- a/src/components/TimespanForm.js
+++ b/src/components/TimespanForm.js
@@ -62,10 +62,7 @@ class TimespanForm extends Component {
       // Update state when segment handles are dragged in the waveform
       if (this.props.peaksInstance !== peaksInstance && !isInitializing) {
         // Prevent from overlapping when dragging the handles
-        const {
-          startTime,
-          endTime
-        } = waveformDataUtils.preventSegmentOverlapping(
+        const { startTime, endTime } = waveformDataUtils.validateSegment(
           segment,
           peaksInstance.peaks
         );
@@ -191,7 +188,12 @@ class TimespanForm extends Component {
     const { beginTime, endTime } = this.state;
     const { allSpans } = this;
 
-    return validTimespans(beginTime, endTime, allSpans, this.props.smData);
+    return validTimespans(
+      beginTime,
+      endTime,
+      allSpans,
+      this.props.peaksInstance.peaks
+    );
   }
 
   render() {
@@ -241,7 +243,8 @@ class TimespanForm extends Component {
               validationState={getValidationEndState(
                 beginTime,
                 endTime,
-                this.allSpans
+                this.allSpans,
+                this.props.peaksInstance.peaks
               )}
             >
               <ControlLabel>End Time</ControlLabel>

--- a/src/components/TimespanInlineForm.js
+++ b/src/components/TimespanInlineForm.js
@@ -82,7 +82,7 @@ class TimespanInlineForm extends Component {
       if (nextProps.segment && !this.state.isTyping) {
         const { segment, peaksInstance } = nextProps;
         // Prevent from overlapping when dragging the handles
-        const { startTime, endTime } = waveformUtils.preventSegmentOverlapping(
+        const { startTime, endTime } = waveformUtils.validateSegment(
           segment,
           peaksInstance.peaks
         );
@@ -101,7 +101,7 @@ class TimespanInlineForm extends Component {
       beginTime,
       endTime,
       this.allSpans,
-      this.tempSmData
+      this.props.peaksInstance.peaks
     );
 
     return titleValid && timesValidResponse.valid;
@@ -182,7 +182,8 @@ class TimespanInlineForm extends Component {
               validationState={getValidationEndState(
                 beginTime,
                 endTime,
-                this.allSpans
+                this.allSpans,
+                this.props.peaksInstance.peaks
               )}
             >
               <ControlLabel>End Time</ControlLabel>

--- a/src/components/__snapshots__/ButtonSection.test.js.snap
+++ b/src/components/__snapshots__/ButtonSection.test.js.snap
@@ -25,8 +25,10 @@ ShallowWrapper {
           "player": Object {
             "_mediaElement": Object {
               "currentTime": 0,
+              "duration": 1738.945306,
             },
             "getCurrentTime": [MockFunction],
+            "getDuration": [MockFunction],
             "seek": [MockFunction],
           },
           "segments": Object {

--- a/src/components/__snapshots__/Waveform.test.js.snap
+++ b/src/components/__snapshots__/Waveform.test.js.snap
@@ -61,8 +61,10 @@ ShallowWrapper {
               "player": Object {
                 "_mediaElement": Object {
                   "currentTime": 0,
+                  "duration": 1738.945306,
                 },
                 "getCurrentTime": [MockFunction],
+                "getDuration": [MockFunction],
                 "seek": [MockFunction],
               },
               "segments": Object {
@@ -180,8 +182,10 @@ ShallowWrapper {
                 "player": Object {
                   "_mediaElement": Object {
                     "currentTime": 0,
+                    "duration": 1738.945306,
                   },
                   "getCurrentTime": [MockFunction],
+                  "getDuration": [MockFunction],
                   "seek": [MockFunction],
                 },
                 "segments": Object {

--- a/src/services/StructuralMetadataUtils.js
+++ b/src/services/StructuralMetadataUtils.js
@@ -204,7 +204,7 @@ export default class StructuralMetadataUtils {
    * @param {*} allSpans - all timespans in the data structure
    * @return {Boolean}
    */
-  doesTimeOverlap(time, allSpans) {
+  doesTimeOverlap(time, allSpans, duration = Number.MAX_SAFE_INTEGER) {
     const { toMs } = this;
     let valid = true;
     time = toMs(time);
@@ -216,6 +216,11 @@ export default class StructuralMetadataUtils {
 
       // Illegal time (falls between existing start/end times)
       if (time >= spanBegin && time < spanEnd) {
+        valid = false;
+        break;
+      }
+      // Time exceeds the end time of the media file
+      if (time / 1000 > duration) {
         valid = false;
         break;
       }

--- a/src/services/form-helper.js
+++ b/src/services/form-helper.js
@@ -49,7 +49,19 @@ export function getValidationBeginState(beginTime, allSpans) {
   return null;
 }
 
-export function getValidationEndState(beginTime, endTime, allSpans) {
+export function getValidationEndState(
+  beginTime,
+  endTime,
+  allSpans,
+  peaksInstance
+) {
+  let duration;
+  if (peaksInstance !== undefined) {
+    if (peaksInstance.player !== undefined) {
+      duration = Math.round(peaksInstance.player.getDuration() * 100) / 100;
+    }
+  }
+
   if (!endTime || endTime.indexOf(':') === -1) {
     return null;
   }
@@ -57,7 +69,8 @@ export function getValidationEndState(beginTime, endTime, allSpans) {
   const validFormat = structuralMetadataUtils.validTimeFormat(endTime);
   const validEndTime = structuralMetadataUtils.doesTimeOverlap(
     endTime,
-    allSpans
+    allSpans,
+    duration
   );
   const validOrdering = structuralMetadataUtils.validateBeforeEndTimeOrder(
     beginTime,
@@ -102,7 +115,13 @@ export function isTitleValid(title) {
  *
  * This function also preps handy feedback messages we might want to display to the user
  */
-export function validTimespans(beginTime, endTime, allSpans, smData) {
+export function validTimespans(beginTime, endTime, allSpans, peaksInstance) {
+  let duration;
+  if (peaksInstance !== undefined) {
+    if (peaksInstance.player !== undefined) {
+      duration = Math.round(peaksInstance.player.getDuration() * 100) / 100;
+    }
+  }
   // Valid formats?
   if (!structuralMetadataUtils.validTimeFormat(beginTime)) {
     return {
@@ -143,6 +162,13 @@ export function validTimespans(beginTime, endTime, allSpans, smData) {
     return {
       valid: false,
       message: 'New timespan region overlaps an existing timespan region'
+    };
+  }
+  // Timespan end time is greater than end time of the media file
+  if (duration < structuralMetadataUtils.toMs(endTime) / 1000) {
+    return {
+      valid: false,
+      message: 'End time overlaps duration of the media file'
     };
   }
 


### PR DESCRIPTION
When a segment is added to the end of the media file, the end time exceeds the end time of the media file, which leads to missing handles when trying to edit that segment. A condition was added to check this at the time of inserting a new timespan.
This fixes #50 