### PR TITLE
42 warn user about deleting item

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -31,6 +31,10 @@ section {
   margin-bottom: 10px;
 }
 
+.edit-controls-wrapper {
+  position: relative;
+}
+
 .edit-controls-wrapper a {
   margin: 0 5px;
   cursor: pointer;

--- a/src/components/ListItem.js
+++ b/src/components/ListItem.js
@@ -65,10 +65,6 @@ class ListItem extends Component {
   };
 
   handleEditClick = () => {
-    /* eslint-disable */
-    const { id, type } = this.props.item;
-    /* eslint-enable */
-
     // Disable the edit buttons of other list items
     this.props.handleEditingTimespans(0);
 
@@ -124,6 +120,11 @@ class ListItem extends Component {
     } = this.props;
 
     const subMenu = items && items.length > 0 ? <List items={items} /> : null;
+    const itemProp = {
+      childrenCount: item.items ? item.items.length : 0,
+      label: item.label,
+      type: item.type
+    };
 
     return connectDragSource(
       connectDropTarget(
@@ -148,7 +149,7 @@ class ListItem extends Component {
               <ListItemControls
                 handleDelete={this.handleDelete}
                 handleEditClick={this.handleEditClick}
-                itemType={type}
+                item={itemProp}
                 handleShowDropTargetsClick={this.handleShowDropTargetsClick}
               />
             </div>

--- a/src/components/ListItemControls.js
+++ b/src/components/ListItemControls.js
@@ -1,24 +1,92 @@
-import React from 'react';
-import { Button, OverlayTrigger, Tooltip } from 'react-bootstrap';
+import React, { Component } from 'react';
+import {
+  Button,
+  ButtonToolbar,
+  OverlayTrigger,
+  Popover,
+  Tooltip
+} from 'react-bootstrap';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { connect } from 'react-redux';
+import { handleEditingTimespans } from '../actions/show-forms';
+
+const styles = {
+  buttonToolbar: {
+    display: 'flex',
+    justifyContent: 'flex-end'
+  }
+};
 
 const tooltip = tip => <Tooltip id="tooltip">{tip}</Tooltip>;
 
-const ListItemControls = props => {
-  const {
-    itemType,
-    handleShowDropTargetsClick,
-    handleEditClick,
-    handleDelete,
-    showForms
-  } = props;
+// const popoverTop = message => (
+//   <Popover id="popover-positioned-top" title="Popover top">
+//     <strong>Holy guacamole!</strong> Check this info.
+//   </Popover>
+// );
 
-  return (
-    <div className="edit-controls-wrapper">
-      {itemType === 'span' && (
-        <OverlayTrigger placement="left" overlay={tooltip('Show drop targets')}>
+class ListItemControls extends Component {
+  static propTypes = {
+    handleShowDropTargetsClick: PropTypes.func,
+    handleEditClick: PropTypes.func,
+    handleDelete: PropTypes.func,
+    item: PropTypes.shape({
+      childrenCount: PropTypes.number,
+      label: PropTypes.string.isRequired,
+      type: PropTypes.string
+    })
+  };
+
+  state = {
+    deleteMessage: '',
+    showDeleteConfirm: false
+  };
+
+  handleConfirmDelete = () => {
+    this.props.handleDelete();
+    this.setState({ deleteMessage: '', showDeleteConfirm: false });
+  };
+
+  handleDeleteClick = e => {
+    const { childrenCount, label } = this.props.item;
+    let deleteMessage = `Are you sure you'd like to delete "${label}"`;
+
+    // Disable editing of other list items
+    this.props.handleEditingTimespans(0);
+
+    if (childrenCount > 0) {
+      deleteMessage += ` and it's ${childrenCount} child items`;
+    }
+    deleteMessage += `?`;
+
+    this.setState({
+      deleteMessage,
+      showDeleteConfirm: true
+    });
+  };
+
+  cancelDeleteClick = e => {
+    // Enable editing of other list items
+    this.props.handleEditingTimespans(1);
+
+    this.setState({
+      showDeleteConfirm: false
+    });
+  };
+
+  render() {
+    const {
+      handleShowDropTargetsClick,
+      handleEditClick,
+      item,
+      showForms
+    } = this.props;
+    const { deleteMessage, showDeleteConfirm } = this.state;
+
+    return (
+      <div className="edit-controls-wrapper">
+        {item.type === 'span' && (
           <Button
             bsStyle="link"
             disabled={showForms.disabled}
@@ -26,9 +94,7 @@ const ListItemControls = props => {
           >
             <FontAwesomeIcon icon="dot-circle" />
           </Button>
-        </OverlayTrigger>
-      )}
-      <OverlayTrigger placement="top" overlay={tooltip('Edit')}>
+        )}
         <Button
           bsStyle="link"
           onClick={handleEditClick}
@@ -36,31 +102,54 @@ const ListItemControls = props => {
         >
           <FontAwesomeIcon icon="pen" />
         </Button>
-      </OverlayTrigger>
-      {itemType !== 'root' && (
-        <OverlayTrigger placement="right" overlay={tooltip('Delete')}>
+
+        {item.type !== 'root' && (
           <Button
             bsStyle="link"
-            onClick={handleDelete}
+            onClick={this.handleDeleteClick}
             disabled={showForms.disabled}
           >
             <FontAwesomeIcon icon="trash" />
           </Button>
-        </OverlayTrigger>
-      )}
-    </div>
-  );
-};
+        )}
+        {showDeleteConfirm && (
+          <Popover
+            id="delete-confirm-popover"
+            title="Confirm delete?"
+            placement="top"
+            positionTop={-120}
+            positionLeft={-70}
+            style={{ height: 'auto', width: 250 }}
+          >
+            <p>{deleteMessage}</p>
+            <ButtonToolbar style={styles.buttonToolbar}>
+              <Button
+                bsStyle="danger"
+                bsSize="xsmall"
+                onClick={this.handleConfirmDelete}
+              >
+                Delete
+              </Button>
+              <Button bsSize="xsmall" onClick={this.cancelDeleteClick}>
+                Cancel
+              </Button>
+            </ButtonToolbar>
+          </Popover>
+        )}
+      </div>
+    );
+  }
+}
 
-ListItemControls.propTypes = {
-  handleShowDropTargetsClick: PropTypes.func,
-  handleEditClick: PropTypes.func,
-  handleDelete: PropTypes.func,
-  itemType: PropTypes.string
-};
+const mapDispatchToProps = dispatch => ({
+  handleEditingTimespans: code => dispatch(handleEditingTimespans(code))
+});
 
 const mapStateToProps = state => ({
   showForms: state.showForms
 });
 
-export default connect(mapStateToProps)(ListItemControls);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(ListItemControls);


### PR DESCRIPTION
fixes #42 
fixes #58 

This adds the following Bootstrap popover to confirm deleting of an item:

![delete-confirm1](https://user-images.githubusercontent.com/3020266/54381421-b9854d00-465b-11e9-85d0-147e76afdf31.png)

![delete-confirm2](https://user-images.githubusercontent.com/3020266/54381422-b9854d00-465b-11e9-894d-3346fc4e1b1a.png)
