### PR TITLE
Fix adding segments at the end of the waveform

### DIFF
--- a/src/__mocks__/peaks.js
+++ b/src/__mocks__/peaks.js
@@ -33,9 +33,13 @@ export const Peaks = jest.fn(opts => {
   };
   peaks.segments = {
     getSegment: jest.fn(id => {
-      return peaks.segments._segments.find(seg => {
+      let segment = peaks.segments._segments.find(seg => {
         return seg.id === id;
       });
+      if (segment === undefined) {
+        return null;
+      }
+      return segment;
     }),
     getSegments: jest.fn(() => {
       return peaks.segments._segments;
@@ -43,9 +47,14 @@ export const Peaks = jest.fn(opts => {
     removeAll: jest.fn(() => {
       peaks.segments._segments = [];
     }),
-    add: jest.fn(segment => {
-      let index = peaks.segments._segments.length;
-      peaks.segments._segments.splice(index, 0, segment);
+    add: jest.fn(segments => {
+      if (Array.isArray(segments)) {
+        segments.forEach(segment => {
+          peaks.segments._segments.push(segment);
+        });
+      } else {
+        peaks.segments._segments.push(segments);
+      }
     }),
     removeById: jest.fn(id => {
       let index = peaks.segments._segments.map(seg => seg.id).indexOf(id);

--- a/src/components/Waveform.test.js
+++ b/src/components/Waveform.test.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import Waveform, { PureWaveform } from '../components/Waveform';
 import { shallow, mount } from 'enzyme';
-import configureMockStore from 'redux-mock-store';
+import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { Provider } from 'react-redux';
 import Peaks from 'peaks';
 
-const mockStore = configureMockStore([thunk]);
+const mockStore = configureStore([thunk]);
 
 describe('Waveform component', () => {
   let store, peaks;

--- a/src/components/__snapshots__/ButtonSection.test.js.snap
+++ b/src/components/__snapshots__/ButtonSection.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ButtonSection component component renders wiithout crashing 1`] = `
+exports[`ButtonSection component component renders without crashing 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <ButtonSection
@@ -158,6 +158,7 @@ ShallowWrapper {
     "nodeType": "host",
     "props": Object {
       "children": Array [
+        <AlertContainer />,
         <Row
           bsClass="row"
           componentClass="div"
@@ -250,6 +251,15 @@ ShallowWrapper {
     },
     "ref": null,
     "rendered": Array [
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "class",
+        "props": Object {},
+        "ref": null,
+        "rendered": null,
+        "type": [Function],
+      },
       Object {
         "instance": null,
         "key": undefined,
@@ -507,6 +517,7 @@ ShallowWrapper {
       "nodeType": "host",
       "props": Object {
         "children": Array [
+          <AlertContainer />,
           <Row
             bsClass="row"
             componentClass="div"
@@ -599,6 +610,15 @@ ShallowWrapper {
       },
       "ref": null,
       "rendered": Array [
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "class",
+          "props": Object {},
+          "ref": null,
+          "rendered": null,
+          "type": [Function],
+        },
         Object {
           "instance": null,
           "key": undefined,

--- a/src/containers/AlertContainer.js
+++ b/src/containers/AlertContainer.js
@@ -1,11 +1,13 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Alert } from 'react-bootstrap';
+import { isEmpty } from 'lodash';
 
 class AlertContainer extends Component {
   static propTypes = {
     message: PropTypes.string,
-    alertStyle: PropTypes.oneOf(['success', 'warning', 'danger', 'info'])
+    alertStyle: PropTypes.oneOf(['success', 'warning', 'danger', 'info']),
+    clearAlert: PropTypes.func
   };
 
   state = {
@@ -23,9 +25,15 @@ class AlertContainer extends Component {
       this.setState({ show: true });
     }
   }
+  componentWillReceiveProps(nextProps) {
+    if (isEmpty(nextProps)) {
+      this.setState({ show: false });
+    }
+  }
 
   handleDismiss = () => {
     this.setState({ show: false });
+    this.props.clearAlert();
   };
 
   render() {

--- a/src/containers/AlertContainer.test.js
+++ b/src/containers/AlertContainer.test.js
@@ -2,20 +2,29 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import AlertContainer from './AlertContainer';
 
-const props = {
-  message: 'Ima test message',
-  alertStyle: 'warning'
-};
-
 describe('AlertContainer', () => {
+  let props, mockClearAlert;
+  beforeEach(() => {
+    props = {
+      message: 'Ima test message',
+      alertStyle: 'warning',
+      clearAlert: jest.fn()
+    };
+
+    mockClearAlert = jest.fn(() => {
+      props = null;
+    });
+  });
   it('renders without crashing', () => {
     const wrapper = shallow(<AlertContainer {...props} />);
     expect(wrapper.find('Alert')).toHaveLength(1);
   });
 
   it('closes when state updates to not display the alert message', () => {
+    props.clearAlert = mockClearAlert();
     const wrapper = shallow(<AlertContainer {...props} />);
     wrapper.setState({ show: false });
     expect(wrapper.find('Alert')).toHaveLength(0);
+    expect(props).toBeNull();
   });
 });

--- a/src/containers/StructureOutputContainer.js
+++ b/src/containers/StructureOutputContainer.js
@@ -68,9 +68,15 @@ class StructureOutputContainer extends Component {
     }
   }
 
+  clearAlert = () => {
+    this.setState({
+      alertObj: null
+    });
+  };
+
   handleFetchError(error) {
     let status = error.response !== undefined ? error.response.status : -2;
-    const alertObj = configureAlert(status);
+    const alertObj = configureAlert(status, this.clearAlert);
 
     this.setState({ alertObj });
   }
@@ -81,7 +87,7 @@ class StructureOutputContainer extends Component {
       error.response !== undefined
         ? error.response.status
         : error.request.status;
-    const alertObj = configureAlert(status);
+    const alertObj = configureAlert(status, this.clearAlert);
 
     this.setState({ alertObj });
   }
@@ -92,9 +98,9 @@ class StructureOutputContainer extends Component {
       .postRequest('structure.json', postData)
       .then(response => {
         const { status } = response;
-        const alertObj = configureAlert(status);
+        const alertObj = configureAlert(status, this.clearAlert);
 
-        this.setState({ alertObj, showAlert: true });
+        this.setState({ alertObj });
       })
       .catch(error => {
         this.handleSaveError(error);

--- a/src/containers/WaveformContainer.js
+++ b/src/containers/WaveformContainer.js
@@ -39,6 +39,12 @@ class WaveformContainer extends Component {
     this.initializePeaks();
   }
 
+  clearAlert = () => {
+    this.setState({
+      alertObj: null
+    });
+  };
+
   handleError(error) {
     console.log('TCL: WaveformContainer -> handleError -> error', error);
     let status = null;
@@ -50,7 +56,7 @@ class WaveformContainer extends Component {
       status = -3;
     }
 
-    const alertObj = configureAlert(status);
+    const alertObj = configureAlert(status, this.clearAlert);
     this.setState({ alertObj, error: true });
   }
 
@@ -78,12 +84,7 @@ class WaveformContainer extends Component {
           />
         </WaveformErrorBoundary>
 
-        {alertObj && (
-          <AlertContainer
-            message={alertObj.message}
-            alertStyle={alertObj.alertStyle}
-          />
-        )}
+        {alertObj && <AlertContainer {...alertObj} />}
       </section>
     );
   }

--- a/src/services/WaveformDataUtils.js
+++ b/src/services/WaveformDataUtils.js
@@ -88,7 +88,7 @@ export default class WaveformDataUtils {
     currentSegments.map(segment => {
       if (rangeBeginTime < segment.startTime) {
         const segmentLength = segment.endTime - segment.startTime;
-        if (segmentLength < 60) {
+        if (segmentLength < 60 && rangeEndTime >= segment.endTime) {
           rangeEndTime = segment.startTime - 0.01;
         }
         if (
@@ -104,16 +104,18 @@ export default class WaveformDataUtils {
       return rangeEndTime;
     });
 
-    // Move playhead to start of the temporary segment
-    peaksInstance.player.seek(rangeBeginTime);
+    if (rangeBeginTime < fileEndTime && rangeEndTime > rangeBeginTime) {
+      // Move playhead to start of the temporary segment
+      peaksInstance.player.seek(rangeBeginTime);
 
-    peaksInstance.segments.add({
-      startTime: rangeBeginTime,
-      endTime: rangeEndTime,
-      editable: true,
-      color: COLOR_PALETTE[2],
-      id: 'temp-segment'
-    });
+      peaksInstance.segments.add({
+        startTime: rangeBeginTime,
+        endTime: rangeEndTime,
+        editable: true,
+        color: COLOR_PALETTE[2],
+        id: 'temp-segment'
+      });
+    }
 
     return peaksInstance;
   }

--- a/src/services/WaveformDataUtils.test.js
+++ b/src/services/WaveformDataUtils.test.js
@@ -217,6 +217,29 @@ describe('WaveformDataUtils class', () => {
           ])
         );
       });
+
+      test('when there are multiple small segments with a length of less than 60 seconds', () => {
+        peaks.segments.add({
+          startTime: 1690,
+          endTime: 1738.95,
+          id: '123a-456b-789c-9d',
+          color: '#2A5459',
+          labelText: 'Test segment'
+        });
+        peaks.player.seek(450);
+        const value = waveformUtils.insertTempSegment(peaks);
+        expect(value.segments._segments).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              startTime: 480.01,
+              endTime: 540.01,
+              id: 'temp-segment',
+              color: '#FBB040',
+              editable: true
+            })
+          ])
+        );
+      });
     });
 
     describe('deletes segments when structure metadata items are deleted', () => {

--- a/src/services/alert-status.js
+++ b/src/services/alert-status.js
@@ -6,13 +6,16 @@ export const FETCH_STRUCTURED_DATA_ERROR =
   'There was an error fetching the Structured Metadata from server';
 export const PEAKJS_INITIALIZE_ERROR =
   'There was an error initializing the PeakJS waveform';
+export const PEAKSJS_REACHED_END_OF_FILE =
+  'Time ahead has timespans reaching the end of media file, there is no available time to insert a new timespan';
 
 /**
  * Helper function which prepares a configuration object to feed the AlertContainer component
  * @param {number} status Code for response
+ * @param {function} clearAlert A function defined in the hosting component to clear the alert object in component's state
  */
-export function configureAlert(status) {
-  let alertObj = { alertStyle: 'danger' };
+export function configureAlert(status, clearAlert) {
+  let alertObj = { alertStyle: 'danger', clearAlert: clearAlert };
 
   if (status === 401) {
     alertObj.message = UNAUTHORIZED_ACCESS;
@@ -25,9 +28,11 @@ export function configureAlert(status) {
     alertObj.message = FETCH_STRUCTURED_DATA_ERROR;
   } else if (status === -3) {
     alertObj.message = PEAKJS_INITIALIZE_ERROR;
+  } else if (status === -4) {
+    alertObj.alertStyle = 'warning';
+    alertObj.message = PEAKSJS_REACHED_END_OF_FILE;
   } else {
     alertObj.message = NETWORK_ERROR;
   }
-
   return alertObj;
 }


### PR DESCRIPTION
fixes #56
fixes #54 

To clear the `alertObj` in each parent component a function is defined to clear its state. And this function is then invoked within the `AlertContainer` when closing the alert. This clears up the object for the alert and fixes the bug in #54.