### PR TITLE
Add stream URL for audio player

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "cpy-cli": "^2.0.0",
     "enzyme": "^3.8.0",
     "enzyme-adapter-react-16": "^1.8.0",
+    "hls.js": "0.12.3-canary.4258",
     "lodash": "^4.17.11",
     "moment": "^2.22.2",
     "peaks.js": "^0.9.13",

--- a/src/components/Waveform.js
+++ b/src/components/Waveform.js
@@ -9,7 +9,7 @@ import {
   Col
 } from 'react-bootstrap';
 import { connect } from 'react-redux';
-import soundMP3 from '../data/utah_phillips_one.mp3';
+import Hls from 'hls.js';
 
 // Content of aria-label for UI components
 const waveformLabel = `Two interactive waveforms, plotted one after the other using data from a masterfile in the back-end server.
@@ -24,7 +24,8 @@ class Waveform extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      seekTime: ''
+      seekTime: '',
+      audioFile: this.props.mp3URL
     };
 
     // Create `refs`
@@ -36,6 +37,17 @@ class Waveform extends Component {
   }
 
   componentDidMount() {
+    const { audioFile } = this.state;
+    if (Hls.isSupported()) {
+      const hls = new Hls();
+      // Bind media player
+      hls.attachMedia(this.mediaPlayer.current);
+      // MEDIA_ATTACHED event is fired by hls object once MediaSource is ready
+      hls.on(Hls.Events.MEDIA_ATTACHED, function() {
+        hls.loadSource(audioFile);
+      });
+    }
+
     // Grab the React `refs` now the component is mounted
     this.props.waveformRef(this.waveformContainer.current);
     this.props.mediaPlayerRef(this.mediaPlayer.current);
@@ -81,8 +93,6 @@ class Waveform extends Component {
             <audio
               controls
               ref={this.mediaPlayer}
-              src={soundMP3}
-              type="audio/mp3"
               aria-label={audioControlsLabel}
             >
               Your browser does not support the audio element.

--- a/src/components/Waveform.js
+++ b/src/components/Waveform.js
@@ -25,7 +25,7 @@ class Waveform extends Component {
     super(props);
     this.state = {
       seekTime: '',
-      audioFile: this.props.mp3URL
+      audioFile: this.props.audioStreamURL
     };
 
     // Create `refs`

--- a/src/components/Waveform.test.js
+++ b/src/components/Waveform.test.js
@@ -52,9 +52,6 @@ describe('Waveform component', () => {
     });
 
     test('renders audio element with src attribute', () => {
-      expect(wrapper.find('audio').instance().src).toBe(
-        'http://localhost/utah_phillips_one.mp3'
-      );
       expect(wrapper.find('audio').instance().controls).toBeTruthy();
     });
 

--- a/src/containers/WaveformContainer.js
+++ b/src/containers/WaveformContainer.js
@@ -86,7 +86,7 @@ class WaveformContainer extends Component {
 
   render() {
     const { alertObj, hasError } = this.state;
-    const { forms } = this.props;
+    const { forms, mp3URL } = this.props;
 
     return (
       <section className="waveform-section">
@@ -96,6 +96,7 @@ class WaveformContainer extends Component {
           <Waveform
             waveformRef={ref => (this.waveformContainer = ref)}
             mediaPlayerRef={ref => (this.mediaPlayer = ref)}
+            mp3URL={mp3URL}
           />
         )}
       </section>

--- a/src/containers/WaveformContainer.js
+++ b/src/containers/WaveformContainer.js
@@ -86,7 +86,7 @@ class WaveformContainer extends Component {
 
   render() {
     const { alertObj, hasError } = this.state;
-    const { forms, mp3URL } = this.props;
+    const { forms, audioStreamURL } = this.props;
 
     return (
       <section className="waveform-section">
@@ -96,7 +96,7 @@ class WaveformContainer extends Component {
           <Waveform
             waveformRef={ref => (this.waveformContainer = ref)}
             mediaPlayerRef={ref => (this.mediaPlayer = ref)}
-            mp3URL={mp3URL}
+            audioStreamURL={audioStreamURL}
           />
         )}
       </section>

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ const props = {
   baseURL: 'https://spruce.dlib.indiana.edu',
   masterFileID: 'd791sg30j',
   initStructure: '',
-  mp3URL: ''
+  mp3URL: 'https://video-dev.github.io/streams/x36xhzz/x36xhzz.m3u8'
 };
 
 ReactDOM.render(<Root {...props} />, document.getElementById('root'));

--- a/src/index.js
+++ b/src/index.js
@@ -5,9 +5,10 @@ import Root from './Root';
 
 const props = {
   baseURL: 'https://spruce.dlib.indiana.edu',
-  masterFileID: 'd791sg30j',
+  masterFileID: 'sj1392061',
   initStructure: '',
-  mp3URL: 'https://video-dev.github.io/streams/x36xhzz/x36xhzz.m3u8'
+  audioStreamURL:
+    'https://spruce.dlib.indiana.edu/master_files/sj1392061/auto.m3u8'
 };
 
 ReactDOM.render(<Root {...props} />, document.getElementById('root'));

--- a/yarn.lock
+++ b/yarn.lock
@@ -4104,7 +4104,7 @@ eventemitter2@~5.0.1:
   resolved "https://registry.yarnpkg.com/eventemitter2/-/eventemitter2-5.0.1.tgz#6197a095d5fb6b57e8942f6fd7eaad63a09c9452"
   integrity sha1-YZegldX7a1folC9v1+qtY6CclFI=
 
-eventemitter3@^3.0.0:
+eventemitter3@3.1.0, eventemitter3@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.0.tgz#090b4d6cdbd645ed10bf750d4b5407942d7ba163"
   integrity sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA==
@@ -5131,6 +5131,14 @@ hex-color-regex@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
+
+hls.js@0.12.3-canary.4258:
+  version "0.12.3-canary.4258"
+  resolved "https://registry.yarnpkg.com/hls.js/-/hls.js-0.12.3-canary.4258.tgz#9ef7e89a85609222497512b9baed806712246901"
+  integrity sha512-uSNt4fDVNb5rMpgMGjFvVaIqWwwRnIFiCrTY2zHCIQbaKgw8DOhA3QC5ImYdv8nXiZod5LS69dYxjnj/u8+3nw==
+  dependencies:
+    eventemitter3 "3.1.0"
+    url-toolkit "^2.1.6"
 
 hmac-drbg@^1.0.0:
   version "1.0.1"
@@ -11300,6 +11308,11 @@ url-parse@^1.4.3:
   dependencies:
     querystringify "^2.0.0"
     requires-port "^1.0.0"
+
+url-toolkit@^2.1.6:
+  version "2.1.6"
+  resolved "https://registry.yarnpkg.com/url-toolkit/-/url-toolkit-2.1.6.tgz#6d03246499e519aad224c44044a4ae20544154f2"
+  integrity sha512-UaZ2+50am4HwrV2crR/JAf63Q4VvPYphe63WGeoJxeu8gmOm0qxPt+KsukfakPNrX9aymGNEkkaoICwn+OuvBw==
 
 url@^0.11.0:
   version "0.11.0"


### PR DESCRIPTION
Add support for the stream URL in the audio player with `hls.js`

Currently the version `0.12.3-canary.4258` of `hls.js` works with React due to some issues with latest version of `hls.js` having a problem when building react apps created with `create-react-app`.

Therefore, when in the packaging repo, after pulling in these changes you have to;
`yarn add hls.js@0.12.3-canary.4258`